### PR TITLE
Fix kgsl double free due to merge conflict.

### DIFF
--- a/drivers/gpu/msm/kgsl.c
+++ b/drivers/gpu/msm/kgsl.c
@@ -908,9 +908,6 @@ static void kgsl_destroy_process_private(struct kref *kref)
 	if (private->debug_root)
 		debugfs_remove_recursive(private->debug_root);
 
-	kgsl_mmu_putpagetable(private->pagetable);
-	idr_destroy(&private->mem_idr);
-
 	list_del(&private->list);
 	mutex_unlock(&kgsl_driver.process_mutex);
 


### PR DESCRIPTION
Caused by conflict between e5f0aab82 and 757f3d011.

Change-Id: If621c5e59a1d95a0488f0b7cb81bd1913d223d62